### PR TITLE
Move argument out of group.

### DIFF
--- a/launch/person_sample.launch
+++ b/launch/person_sample.launch
@@ -28,9 +28,9 @@
   <arg name="subscribe_rate"    default="30" />
   <arg name="detection_rate"    default="30" />
   <arg name="tracking_rate"     default="30" />
+  <arg name="manager"           default="manager" />
 
   <group ns="$(arg camera)">
-    <arg name="manager"        default="manager" />
     <!-- Load manager -->
     <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
 


### PR DESCRIPTION
The manager name argument should not be
inside the group itself. Having it in this
location causes an error where it cannot be
assigned via launch file (command line
assignment seems to work fine, so presumably
this is a bug in roslaunch). Moving the argument
out of the group appears to work fine in both
launch files and via command line.