### PR TITLE
Updated get_tracking_state service to remove current_tracking_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Install the package and its dependent packages as follows:
 `detection_data` ([realsense_person/PersonDetection](msg/PersonDetection.msg))
 
    Contains the basic information of all the people detected in a frame.
+   If a person is being tracked, it will return the information of only that person.
 
 `detection_image` ([sensor_msgs/Image](http://docs.ros.org/api/sensor_msgs/html/msg/Image.html))
 
@@ -86,7 +87,7 @@ Install the package and its dependent packages as follows:
 
    Contains detailed information of the person being tracked.
    <b>Note:</b> Use the "start_tracking_person" service to start tracking a person. If a person is not being tracked,
-   this topic will not have any data.
+   this topic will not be published.
 
    The information contained in this topic can be controlled using the parameters
    "enable_head_bounding_box", "enable_face_landmarks", "enable_gestures"
@@ -103,8 +104,8 @@ Install the package and its dependent packages as follows:
 ###Services
 `get_tracking_state` ([realsense_person/GetTrackingState](srv/GetTrackingState.srv))
 
-   Returns the tracking state which includes the tracking_id of the person currently being tracked
-   along with a list of tracking_ids of all the people detected in the latest frame.
+   Returns the tracking state. If nobody is being tracked, it will return the list of tracking_ids of all the detected people.
+   If a person is being tracked, it will return the tracking_id of just that person.
 
 `register_person` ([realsense_person/Register](srv/Register.srv))
 

--- a/srv/GetTrackingState.srv
+++ b/srv/GetTrackingState.srv
@@ -1,12 +1,15 @@
 #######################################################################################################################
 # state -1: indicates failure.
-# state  0: indicates that currently nobody is being tracked; ignore the "current_tracking_id".
-# state  1: indicates that currently a person is being tracked.
+# state  0: indicates that currently nobody is being tracked.
+#           all the detected tracking_ids will be listed.
+# state  1: indicates that currently a person is being tracked; 
+#           only the tracking_id of the person being tracked will be listed.
+# state  2: indicates that the tracking_id being tracked is no more in frame;
+#           tracking_ids list will be empty
 #######################################################################################################################
 
 ---
 int32 state
 string state_desc
-int32 current_tracking_id      #tracking_id of the person being currently tracked
-int32[] detected_tracking_ids  #list of tracking_ids of detected people
+int32[] tracking_ids
 

--- a/test/person_detection.cpp
+++ b/test/person_detection.cpp
@@ -89,7 +89,7 @@ TEST(RealsensePerson, RegisterService)
 {
   realsense_person::GetTrackingState get_tracking_state_service;
   g_get_tracking_state_client.call(get_tracking_state_service);
-  g_tracking_ids = get_tracking_state_service.response.detected_tracking_ids;
+  g_tracking_ids = get_tracking_state_service.response.tracking_ids;
 
   bool registered_all = true;
 


### PR DESCRIPTION
Updated code to publish tracking topics only if a person is being tracked.

**Please ensure the above *guidelines for contributing* are met.**

Fixes Issue: #

Changes proposed in this pull request:
- Updated "get_tracking_state" service to remove current_tracking_id
  - Also added a state for this service where the tracking was started but the tracking_id (person) went out of the frame.
- Updated code to publish tracking topics only if a person is being tracked. 
  This was a bug that QA had found.


