### PR TITLE
Removed detection_rate and tracking_rate parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,15 +135,11 @@ Refer to the defintion at ([Custom Messages](msg/)).
 `subscribe_rate` (default: 30)
 
    Controls the subscription rate of the color and depth topics.
+   To reduce latency, the user is not given a separate rate control for publishing topics.
+   Instead, the package will try to publish topics at the subscribe_rate.
+   <b>Note:</b> The latency in publishing messages is also proportional to the features enabled by the user.
 
 ###Dynamic Parameters
-`detection_rate` (default: 30)
-
-   Controls the publish rate of the detection topics.
-
-`tracking_rate` (default: 30)
-
-   Controls the publish rate of the tracking topics.
 
 `enable_recognition` (default: true)
 

--- a/cfg/person_params.cfg
+++ b/cfg/person_params.cfg
@@ -7,8 +7,6 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 gen = ParameterGenerator()
 
 #             Name                               Type      Level  Description                     Default  Min   Max
-gen.add("detection_rate",                        int_t,    0,     "Detection Rate in Hz",         30,      1,    60)
-gen.add("tracking_rate",                         int_t,    0,     "Tracking Rate in Hz",          30,      1,    60)
 gen.add("enable_recognition",                    bool_t,   0,     "Enable Recognition",           True)
 
 #TODO: Temporarily removed in MW Beta3 version

--- a/include/realsense_person/person_nodelet.h
+++ b/include/realsense_person/person_nodelet.h
@@ -93,12 +93,7 @@ namespace realsense_person
     std::string nodelet_name_;
     int tracking_id_;
     int subscribe_rate_;
-    int detection_rate_;
-    int tracking_rate_;
 
-    double current_time_;
-    double last_detection_time_;
-    double last_tracking_time_;
     bool publish_detection_;
     bool publish_detection_image_;
     bool publish_tracking_;
@@ -170,8 +165,7 @@ namespace realsense_person
         const sensor_msgs::ImageConstPtr& image, RSCore::correlated_sample_set &sample_set);
     void processFrame(RSCore::correlated_sample_set sample_set);
     PersonModule::PersonTrackingData* getPersonData();
-    void prepareMsgs(PersonModule::PersonTrackingData* person_data, const sensor_msgs::ImageConstPtr& color_image,
-        double msg_received_time);
+    void prepareMsgs(PersonModule::PersonTrackingData* person_data, const sensor_msgs::ImageConstPtr& color_image);
     Person preparePersonMsg(PersonModule::PersonTrackingData::PersonTracking* detection_data);
     Face prepareFaceMsg(PersonModule::PersonTrackingData::Person* single_person_data);
     Body prepareBodyMsg(PersonModule::PersonTrackingData::Person* single_person_data);

--- a/launch/person_sample.launch
+++ b/launch/person_sample.launch
@@ -28,8 +28,6 @@
   <arg name="subscribe_rate"    default="30" />
 
   <!-- These arguments can be set dynamically too and are provided here just for convenience -->
-  <arg name="detection_rate"            default="30" />
-  <arg name="tracking_rate"             default="30" />
   <arg name="enable_recognition"        default="true" />
   <arg name="enable_head_bounding_box"  default="false" />
   <arg name="enable_gestures"           default="false" />
@@ -61,9 +59,8 @@
     </include>
 
     <!-- Load person -->
+    i
     <param name="$(arg person)/subscribe_rate"            type="int"   value="$(arg subscribe_rate)" />
-    <param name="$(arg person)/detection_rate"            type="int"   value="$(arg detection_rate)" />
-    <param name="$(arg person)/tracking_rate"             type="int"   value="$(arg tracking_rate)" />
     <param name="$(arg person)/enable_recognition"        type="bool"  value="$(arg enable_recognition)" />
     <param name="$(arg person)/enable_head_bounding_box"  type="bool"  value="$(arg enable_head_bounding_box)" />
     <param name="$(arg person)/enable_gestures"           type="bool"  value="$(arg enable_gestures)" />


### PR DESCRIPTION
In order to reduce latency, the package will try to publish messages
at the subscribe_rate. If the user wants to reduce the publish_rate,
the user will have to relaunch the nodelet with the reduced subscribe_rate.


